### PR TITLE
add internet connection requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This Py script will inspect the frequency vectors of the X86PlatformPlugin plist
 
 This script only generates the CPUFriendDataProvider.kext and ssdt_data.dsl/.aml files - those still **require** Acidanthera's [CPUFriend](https://github.com/acidanthera/CPUFriend) kext to function.
 
+This script also requires internet connectivity so that it can download supporting files to build `CPUFriendDataProvider.kext`, `ssdt_data.dsl`, and `ssdt_data.aml`. Without an active internet connection, only the `plist` file will be created.
+
 ## Low Frequency Mode (LFM)
 
 LFM is the lowest frequency at which your CPU should operate when completely idle.  This is the first configuration item prompted by CPUFriendFriend.  It allows you the opportunity to optimize beyond what Apple configures as a default for each model, as it may not be the correct match for your CPU.  To determine the LFM, look your CPU up on Intel's Ark website and convert the TDP-down frequency to Hex.


### PR DESCRIPTION
I was confused and stuck for a few minutes when I was trying to run CPUFriendFriend _without_ an active network connection. I didn't realize it needed to download a few files in order to build.

Although the "downloading" messages in the console would have indicated a problem, those messages were instantaneously cleared as the subsequent prompts was displayed, and I didn't notice them until after I carefully scrolled back up to retrace my steps, assuming I missed an option or input something wrong.

I think adding this notice to the readme will help other people who may be trying to build their systems offline.