### PR TITLE
Add warnings for missing RC/IASL

### DIFF
--- a/CPUFriendFriend.py
+++ b/CPUFriendFriend.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os, sys, plistlib, zipfile, tempfile, binascii, shutil
+from warnings import warn
 from Scripts import *
 
 class CPUFF:
@@ -43,7 +44,7 @@ class CPUFF:
         try:
             self._download_and_extract(temp,self.iasl_url)
         except Exception as e:
-            print("An error occurred :(\n - {}".format(e))
+            warn("An error occurred :(\n - {}".format(e))
         shutil.rmtree(temp, ignore_errors=True)
         # Check again after downloading
         return self.check_iasl(try_downloading=False)
@@ -336,8 +337,12 @@ class CPUFF:
                     out = self.r.run({"args":[self.iasl,x]})
                     if out[2] != 0:
                         print(out[1])
+            else:
+                warn("iasl not found, SSDT not compiled. Network issue?")
             os.chdir(cwd)
             self.r.run({"args":["open",self.out]})
+        else:
+            warn("ResourceConverter not found, Kext not compiled. Network issue?")
         print("")
         print("Done.")
         exit()


### PR DESCRIPTION
My network's shit so it really has a tendency to run without it. The download error display is somehow never useful, so add warnings at compile time.

We could be more helpful and say stuff like "do this to compile without going through the selection", but lazy lazy stuff boring.